### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/lodash": "4.17.24",
     "@types/node": "24.12.2",
     "@vercel/ncc": "0.38.4",
-    "axios": "1.15.0",
+
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@vercel/ncc':
         specifier: 0.38.4
         version: 0.38.4
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       eslint:
         specifier: 10.2.0
         version: 10.2.0
@@ -939,9 +936,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -3825,14 +3819,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/fyb.ts
+++ b/src/fyb.ts
@@ -18,19 +18,27 @@ export class FetchYoutubeBgmApi {
   }
 
   public async getTracks(): Promise<ApiTrack[]> {
-    const res = await fetch(`${this.serverUrl}/api/tracks/`)
-    if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+    const url = `${this.serverUrl}/api/tracks/`
+    const res = await fetch(url)
+    if (!res.ok)
+      throw new Error(
+        `HTTP error: ${res.status} ${res.statusText} (GET ${url})`
+      )
     const data = (await res.json()) as ApiGetTracksResponse
     return data
   }
 
   public async patchTrack(track: ApiTrack): Promise<void> {
-    const res = await fetch(`${this.serverUrl}/api/tracks/${track.vid}`, {
+    const url = `${this.serverUrl}/api/tracks/${track.vid}`
+    const res = await fetch(url, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(track),
     })
-    if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+    if (!res.ok)
+      throw new Error(
+        `HTTP error: ${res.status} ${res.statusText} (PATCH ${url})`
+      )
     if (res.status !== 204) {
       throw new Error('Failed to patch track')
     }

--- a/src/fyb.ts
+++ b/src/fyb.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+// axios から fetch へ移行
 
 export interface ApiTrack {
   vid: string
@@ -18,19 +18,20 @@ export class FetchYoutubeBgmApi {
   }
 
   public async getTracks(): Promise<ApiTrack[]> {
-    const response = await axios.get<ApiGetTracksResponse>(
-      `${this.serverUrl}/api/tracks/`
-    )
-    return response.data
+    const res = await fetch(`${this.serverUrl}/api/tracks/`)
+    if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+    const data = (await res.json()) as ApiGetTracksResponse
+    return data
   }
 
   public async patchTrack(track: ApiTrack): Promise<void> {
-    const response = await axios.patch(
-      `${this.serverUrl}/api/tracks/${track.vid}`,
-      track
-    )
-
-    if (response.status !== 204) {
+    const res = await fetch(`${this.serverUrl}/api/tracks/${track.vid}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(track),
+    })
+    if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+    if (res.status !== 204) {
       throw new Error('Failed to patch track')
     }
   }


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非2xxレスポンスに対するエラーハンドリングを追加