### PR TITLE
chore(pnpm): @book000/* パッケージを minimumReleaseAge チェックから除外

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ allowBuilds:
   classic-level: true
   esbuild: true
   unrs-resolver: true
+minimumReleaseAgeExclude:
+  - '@book000/*'


### PR DESCRIPTION
## 概要

pnpm v11 のデフォルト `minimumReleaseAge`（24 時間）により、`@book000/*` パッケージが
公開直後に Renovate PR の Docker CI が失敗するケースがある。

`pnpm-workspace.yaml` に `minimumReleaseAgeExclude` を追加し、`@book000/*` スコープの
パッケージを pnpm の最小リリース日齢チェックから除外する。

## 変更内容

`pnpm-workspace.yaml` に以下を追加：

```yaml
minimumReleaseAgeExclude:
  - '@book000/*'
```

## 背景

Renovate 設定（`book000/templates//renovate/base-public`）では `@book000/*` は
`stabilityDays` チェックから除外されており、pnpm 側もこれに合わせる。

関連 issue: book000/book000#109