### PR TITLE
fix(tsconfig): ignoreDeprecations を廃止し tsconfig を根本修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -22,12 +22,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
-    "ignoreDeprecations": "6.0",
     "types": ["node"]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 アップグレード時の暫定対応として追加した `ignoreDeprecations: "6.0"` を削除し、根本的な修正を行います。

## 主な変更点

- `moduleResolution` を `Node` から `bundler` に変更
- `baseUrl: "."` を削除
- `paths` を `"@/*": ["src/*"]` から `"@/*": ["./src/*"]` に更新（`baseUrl` 削除に伴い相対パスへ修正）
- `ignoreDeprecations: "6.0"` を削除

## 変更の理由

1. **`moduleResolution: bundler`** — `Node` は TypeScript 6.0 で非推奨。`bundler` が CJS との組み合わせで推奨
2. **`baseUrl` 削除 + `paths` を相対パスに更新** — `baseUrl` を削除した場合、`paths` は tsconfig.json 起点の相対パス `./src/*` に変更が必要
3. **`ignoreDeprecations: "6.0"` 削除** — TypeScript 7.0 では無効化されるため、今のうちに根本対応

## 確認済み事項

- `pnpm compile`（`tsc -p .`）でビルドエラーなし
- `pnpm lint`（ESLint + Prettier + tsc）が全て通過

Fixes #2062