### PR TITLE
fix: unicorn/prefer-https ルール違反の修正

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export interface IConfiguration {
    * - GET `/api/tracks/`: すべてのトラック情報を取得
    * - PATCH `/api/tracks/{vid}`: 指定した動画のトラック情報を追加・更新
    *
-   * @example http://example.com
+   * @example https://example.com
    */
   server: string
 


### PR DESCRIPTION
## 概要

`eslint-plugin-unicorn` v65 で新たに有効化された `unicorn/prefer-https` ルールへの違反を修正します。

## 変更内容

- `src/config.ts` の JSDoc `@example` タグに記載されていた URL を `http://example.com` から `https://example.com` に変更

## 背景

`@book000/eslint-config` のバージョンアップ（eslint-plugin-unicorn v65 系）により、`unicorn/prefer-https` ルールが有効化されました。
このルールは HTTP URL より HTTPS URL を優先することを要求するため、JSDoc コメント内の `@example http://example.com` が lint エラーとなっていました。

## 確認事項

- [x] `pnpm lint` が通ること
- [x] `pnpm test` が通ること（テストなし）

Fixes #2065