### PR TITLE
chore: .worktreeinclude を追加してローカル設定ファイルを worktree 間で共有する

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+data/config.json
+data/


### PR DESCRIPTION
## 概要

`.worktreeinclude` を追加し、`data/config.json`（`data/` 以下）をローカル環境固有の設定ファイルとして git worktree 間で共有できるようにします。

## 変更内容

`.worktreeinclude` を新規作成し、以下の 2 パターンを記載しました。

```
data/config.json
data/
```

## 根拠

- `src/main.ts:14`: `const config = new Configuration('data/config.json')`
- `.gitignore` に `data/` が含まれており、ローカル設定ディレクトリとして Git 管理外になっている
- README.md の「Create a configuration file」節: `data/config.json` を作成し、`fetch-youtube-bgm` サーバの URL やブラウザの `levelDbPath` などマシン固有の値を記述する必要がある
- `package.json` の `dev` / `start` スクリプトはいずれもローカル実行時に `data/config.json` を必要とする
- `.env` や docker-compose 等の設定手段はリポジトリ内に存在しない

## レビュー結果

Lite review を実施し、2 件の指摘（`data/config.json` と `data/` の記載が一部重複している点、`data/` 配下全体が共有対象になる点）を確認しましたが、いずれも本 PR が実装対象とした事前調査のパターン指定どおりであり、意図した記載のため変更していません（詳細は PR コメント参照）。

CI は全て成功、コンフリクトなし。Copilot レビュアーは本リポジトリで設定されていないため、レビュー依頼は行っていません。

## 関連

https://github.com/book000/book000/issues/132
